### PR TITLE
Correct URL of  《Brief History of Machine Learning》

### DIFF
--- a/dl.md
+++ b/dl.md
@@ -7,7 +7,7 @@
 ---
 
 
-* [《Brief History of Machine Learning》](http://blog.csdn.net/bestlinjiayin/article/details/38848257/)
+* [《Brief History of Machine Learning》](http://www.erogol.com/brief-history-machine-learning/)
 
 介绍:这是一篇介绍机器学习历史的文章，介绍很全面，从感知机、神经网络、决策树、SVM、Adaboost到随机森林、Deep Learning.
 


### PR DESCRIPTION
use original URL of  《Brief History of Machine Learning》 instead of CSDN URL  of it